### PR TITLE
Enclose argument to "cd" in quotes

### DIFF
--- a/plugin/projectroot.vim
+++ b/plugin/projectroot.vim
@@ -39,7 +39,7 @@ endf
 
 " ProjectRootCD([file]): changes directory to the project of the given file {{{1
 fun! ProjectRootCD(...)
-  exe 'cd' '"' . ProjectRootGuess(s:getfullname(a:0 ? a:1 : '')) . '"'
+  exe 'cd' fnameescape(ProjectRootGuess(s:getfullname(a:0 ? a:1 : '')))
 endf
 
 command! -nargs=? -complete=file ProjectRootCD :call ProjectRootCD("<args>")
@@ -51,7 +51,7 @@ fun! ProjectRootExe(args)
     ProjectRootCD
     exe join(a:args)
   finally
-    exe 'cd' '"' . olddir . '"'
+    exe 'cd' fnameescape(olddir)
   endtry
 endfun
 


### PR DESCRIPTION
If not enclosed in quotes it will fail on Unix because it treats paths with spaces in them as multiple arguments and cd only takes one. Surprisingly, it works fine on windows.
