### PR TITLE
Fix cd error when root dir cannot be guessed.

### DIFF
--- a/plugin/projectroot.vim
+++ b/plugin/projectroot.vim
@@ -48,7 +48,7 @@ fun! ProjectRootGuess(...)
   endif
   " Not found: return parent directory of current file / file itself.
   let fullfile = s:getfullname(a:0 ? a:1 : '')
-  return filereadable(fullfile) ? fnamemodify(fullfile, ':h') : fullfile
+  return !isdirectory(fullfile) ? fnamemodify(fullfile, ':h') : fullfile
 endf
 
 " ProjectRootCD([file]): changes directory to the project of the given file {{{1


### PR DESCRIPTION
Before this commit, if the root directory cannot be guessed, we return
the directory of a file if it's readable or the complete file if it is
not.

We should be returning the directory of the file if it is a file
(readable or not) or the full path if it is a directory. Failure to
do so results in errors when doing ProjectRootCd in virtual buffers
(such as BufExplorer or Tagbar) or unsaved files. This is particularly
troublesome with an 'au BufEnter'.

Example error:
Cannot find directory "/etc/nginx/sites-available/[BufExplorer]"
