### PR TITLE
Ignore the doc/tags file created by Pathogen's :Helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Hey,

Here's a trivial commit to make using `vim-projecroot` easier with git submodules/Pathogen. Basically this file is created when running `:Helptags` which dirties the repo (which is a bit annoying when the repo is a submodule). Hopefully that makes sense :).

Thanks,
Alexis
