### PR TITLE
Make sure the filereadble() before get parent dir

### DIFF
--- a/plugin/projectroot.vim
+++ b/plugin/projectroot.vim
@@ -48,7 +48,7 @@ fun! ProjectRootGuess(...)
   endif
   " Not found: return parent directory of current file / file itself.
   let fullfile = s:getfullname(a:0 ? a:1 : '')
-  return !isdirectory(fullfile) ? fnamemodify(fullfile, ':h') : fullfile
+  return isdirectory(fullfile) ? fullfile : (filereadable(fullfile) ? fnamemodify(fullfile, ':h') : '' )
 endf
 
 " ProjectRootCD([file]): changes directory to the project of the given file {{{1


### PR DESCRIPTION
We should make sure the file is readable or not before find the parent's directory, it can get rid of `fugitive:///....` files.
