### PR TITLE
prevent recursive/upward lookup from testing '//.{marker}' -- cygwin fix

### DIFF
--- a/autoload/projectroot.vim
+++ b/autoload/projectroot.vim
@@ -27,7 +27,8 @@ function! projectroot#get(...)
     while 1
       let prev=pivot
       let pivot=fnamemodify(pivot, ':h')
-      if filereadable(pivot.'/'.marker) || isdirectory(pivot.'/'.marker)
+      let fn = pivot.(pivot == '/' ? '' : '/').marker
+      if filereadable(fn) || isdirectory(fn)
         return pivot
       endif
       if pivot==prev


### PR DESCRIPTION
When pivot moves up to root (/), this creates a path starting with two slashes, which has special meaning on Cygwin (Samba/CIFS share). This fix just prevents this case.